### PR TITLE
Improve UX

### DIFF
--- a/src/assets/sass/components/projects/_projectDetails.scss
+++ b/src/assets/sass/components/projects/_projectDetails.scss
@@ -14,10 +14,29 @@
         width: 100%;
     }
 
-    .carrousel {
-        .dot {
-            width: 10px;
-            height: 10px;
+    
+        
+    .carousel {
+        border-radius: 8px;
+        box-shadow: 0 5px 10px rgba(0, 0, 0, 0.35);
+        margin-bottom: 30px;
+        overflow: visible;
+        
+        .control-dots {
+            position: absolute;
+            bottom: -30px;
+            margin: 0;
+            
+            .dot {
+                background: var(--titleColor);
+                opacity: 0.4;
+                width: 10px;
+                height: 10px;
+
+                &:hover, &.selected {
+                    opacity: 1;
+                }
+            }
         }
         .carrousel-img {
             border-radius: 8px;
@@ -110,6 +129,10 @@
             .fa-solid {
                 color: var(--titleColor);
             }
+        }
+
+        @media screen and (max-width: 640px) {
+            top: 100%;
         }
 
         .fa-solid {


### PR DESCRIPTION
I took the btn slider out of the carrousel because they were not visible according to some projects.
Change their color according to the theme, dark or light to be visible.
Put a box shadow on the carrousel for better visibility in light mode.
At 640px, put the cross to go back at the bottom of the section, because it wasn't pretty with smaller devices.